### PR TITLE
Remove unused matplotlib import

### DIFF
--- a/app8_web.py
+++ b/app8_web.py
@@ -8,7 +8,6 @@ import pandas as pd
 import numpy as np
 import yaml
 import io
-import matplotlib.pyplot as plt
 import plotly.express as px
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots


### PR DESCRIPTION
## Summary
- Remove matplotlib import from Streamlit app as it was unused

## Testing
- `python -m py_compile app8_web.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8721aaae8832e92ac99f2d744a1b5