### PR TITLE
Pin exact dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Aplicación web desarrollada en Python con Streamlit para simular la economía d
 
 ### Pasos para ejecutar
 
-1. **Instalar dependencias:**
+1. **Instalar dependencias** (versiones exactas definidas en `requirements.txt`):
    ```bash
    pip install -r requirements.txt
    ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-streamlit>=1.28.0
-pandas>=2.0.0
-numpy>=1.24.0
-openpyxl>=3.1.0
-pyyaml>=6.0
-matplotlib>=3.7.0
-plotly>=5.15.0
-numpy-financial>=1.0.0
+streamlit==1.28.0
+pandas==2.0.0
+numpy==1.24.0
+openpyxl==3.1.0
+pyyaml==6.0
+matplotlib==3.7.0
+plotly==5.15.0
+numpy-financial==1.0.0


### PR DESCRIPTION
## Summary
- lock all Python dependencies to exact versions for reproducible installs
- clarify install docs that requirements.txt now specifies exact versions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8721d3a2c832e9abea1a1de43b46c